### PR TITLE
Highlight social links on hover, keep brand colors.

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -1,19 +1,34 @@
-a:hover {
-    text-decoration: none;
-}
-
 .card {
     margin-bottom: 10px;
 }
 
-.github {
+a.github {
     color: #24292e;
 }
 
-.meetup {
+a.meetup {
     color: #ed1c40;
 }
 
-.twitter {
+a.twitter {
     color: #1da1f2;
 }
+
+a:hover,
+a:focus {
+    text-decoration: none;
+}
+
+/* highlight social links on hover */
+a.social-link:hover::before {
+    content: "";
+    display: block;
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    top: 0;
+    left: 0;
+    z-index: 1;
+    background-color: rgba(255, 255, 255, 0.125);
+}
+

--- a/css/site.css
+++ b/css/site.css
@@ -19,16 +19,6 @@ a:focus {
     text-decoration: none;
 }
 
-/* highlight social links on hover */
-a.social-link:hover::before {
-    content: "";
-    display: block;
-    position: absolute;
-    height: 100%;
-    width: 100%;
-    top: 0;
-    left: 0;
-    z-index: 1;
-    background-color: rgba(255, 255, 255, 0.125);
+a.social-link:hover {
+    opacity: 0.7;
 }
-

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
     <div class="container">
         <div class="row">
             <div class="col-md">
-                <a class="meetup card" href="https://meetup.com/Central-WI-Developers-Group">
+                <a class="card social-link meetup" href="https://meetup.com/Central-WI-Developers-Group">
                     <div class="card-block text-center">
                         <i class="fa fa-meetup fa-5x"></i>
                         <h1>Meetup</h1>
@@ -42,7 +42,7 @@
             </div>
 
             <div class="col-md">
-                <a class="github card" href="https://github.com/cenwidev">
+                <a class="card social-link github" href="https://github.com/cenwidev">
                     <div class="card-block text-center">
                         <i class="fa fa-github fa-5x"></i>
                         <h1>Github</h1>
@@ -53,7 +53,7 @@
             </div>
 
             <div class="col-md">
-                <a class="twitter card" href="https://twitter.com/cenwidev">
+                <a class="card social-link twitter" href="https://twitter.com/cenwidev">
                     <div class="card-block text-center">
                         <i class="fa fa-twitter fa-5x"></i>
                         <h1>Twitter</h1>


### PR DESCRIPTION
#3 
This overrides the dark blue bootstrap default hover/focus states for the social links.

It is replaced by a subtle highlight.