### PR TITLE
Convert cwitc cta to banner

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -28,7 +28,7 @@
 }
 
 .event-banner-details {
-    padding: 10px;
+    padding-top: 5px;
     flex: 1;
 }
 

--- a/css/site.css
+++ b/css/site.css
@@ -9,7 +9,8 @@
 }
 
 .event-banner-content {
-    margin: 0;
+    margin-left: 10px;
+    flex: 1;
 }
 
 .event-banner-tag {
@@ -34,7 +35,6 @@
 
 .event-banner-more-info {
     padding: 10px;
-    flex: 1;
     align-self: center;
 }
 

--- a/css/site.css
+++ b/css/site.css
@@ -38,24 +38,6 @@
     align-self: center;
 }
 
-.cta {
-    padding: 0;
-}
-
-.cta-anchor {
-    color: #fff;
-    background: #444;
-    padding: 10px;
-    margin: 0;
-}
-
-.cta .card-heading {
-    color: #fff;
-    background: #ec2f4b;
-    padding: 10px;
-    margin-bottom: 10px;
-}
-
 a.github {
     color: #24292e;
 }

--- a/css/site.css
+++ b/css/site.css
@@ -2,6 +2,42 @@
     margin-bottom: 10px;
 }
 
+.event-banner-container {
+    color: #fff;
+    background: #444;
+    padding: 0;
+}
+
+.event-banner-content {
+    margin: 0;
+}
+
+.event-banner-tag {
+    padding: 5px 15px;
+    color: #fff;
+    background: #ec2f4b;
+    font-size: 1em;
+    display: flex;
+    justify-content: center;
+}
+
+.event-banner-tag h1 {
+    font-size: 2em;
+    margin: 0;
+    align-self: center;
+}
+
+.event-banner-details {
+    padding: 10px;
+    flex: 1;
+}
+
+.event-banner-more-info {
+    padding: 10px;
+    flex: 1;
+    align-self: center;
+}
+
 .cta {
     padding: 0;
 }

--- a/index.html
+++ b/index.html
@@ -20,6 +20,22 @@
 </head>
 
 <body>
+    <div class="event-banner-container d-sm-flex">
+        <div class="event-banner-tag text-center text-nowrap">
+            <h1>CWITC 2017</h1>
+        </div>
+        <div class="event-banner-content container d-md-flex">
+            <div class="event-banner-details text-center text-md-left">
+                <div>Central Wisconsin IT Conference</div>
+                <div><small>Join us September 30th 2017</small></div>
+            </div>
+            <div class="event-banner-more-info text-center">
+                <a href="" class="btn btn-primary">More Info</a>
+            </div>
+        </div>
+    </div>
+
+    
     <div class="jumbotron">
         <div class="container">
             <div class="row">

--- a/index.html
+++ b/index.html
@@ -24,13 +24,16 @@
         <div class="event-banner-tag text-center text-nowrap">
             <h1>CWITC 2017</h1>
         </div>
-        <div class="event-banner-content container d-md-flex">
+        <div class="event-banner-content d-md-flex">
             <div class="event-banner-details text-center text-md-left">
                 <div>Central Wisconsin IT Conference</div>
                 <div><small>Join us September 30th 2017</small></div>
             </div>
             <div class="event-banner-more-info text-center">
-                <a href="https://www.cwitc.org/" class="btn btn-primary">More Info</a>
+                <a href="https://www.cwitc.org/" class="btn btn-primary">
+                    More Info 
+                    <i class="fa fa-chevron-right"></i>
+                </a>
             </div>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -34,30 +34,12 @@
             </div>
         </div>
     </div>
-
     
     <div class="jumbotron">
         <div class="container">
-            <div class="row">
-                <div class="col-md-8">
-                    <img src="./img/cenwidev.png" />
-                    <h1>Central Wisconsin Developer's Group</h1>
-                    <p class="lead">Find out more through the social media links below.</p>
-                </div>
-                
-                <div class="col-md-4">
-                    <div class="cta card card-block card-outline text-center">
-                        <p class="cta-anchor">Coming Soon!</p>
-                        <div class="card-heading">
-                            <h1>CWITC 2017</h1>
-                            <div>Central Wisconsin IT Conference</div>
-                        </div>
-                        <div>A Full Day of Amazing Talks</div>
-                        <div><small><b>September 30, 2017</b></small></div>
-                        <a href="https://www.cwitc.org/" class="btn btn-lg btn-link">Find Out More</a>
-                    </div>
-                </div>
-            </div>
+            <img src="./img/cenwidev.png" />
+            <h1>Central Wisconsin Developer's Group</h1>
+            <p class="lead">Find out more through the social media links below.</p>
         </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
                 <div><small>Join us September 30th 2017</small></div>
             </div>
             <div class="event-banner-more-info text-center">
-                <a href="" class="btn btn-primary">More Info</a>
+                <a href="https://www.cwitc.org/" class="btn btn-primary">More Info</a>
             </div>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
         <div class="event-banner-content d-md-flex">
             <div class="event-banner-details text-center text-md-left">
                 <div>Central Wisconsin IT Conference</div>
-                <div><small>Join us September 30th 2017</small></div>
+                <div><small>Join us September 30th, 2017</small></div>
             </div>
             <div class="event-banner-more-info text-center">
                 <a href="https://www.cwitc.org/" class="btn btn-primary">


### PR DESCRIPTION
Converts the original CWITC cta to a banner

small: 
![screen shot 2017-06-11 at 8 02 21 pm](https://user-images.githubusercontent.com/1051245/27016145-f97741ac-4ee1-11e7-92aa-d7d718532318.png)

medium:
![screen shot 2017-06-11 at 8 02 32 pm](https://user-images.githubusercontent.com/1051245/27016152-12f914fc-4ee2-11e7-889d-e7d483c7e516.png)

large:
![screen shot 2017-06-11 at 8 02 45 pm](https://user-images.githubusercontent.com/1051245/27016155-1bba41a6-4ee2-11e7-8f14-fa5766609773.png)

